### PR TITLE
Fixing python3 "dash-separated" warning

### DIFF
--- a/my_doosan_pkg/setup.cfg
+++ b/my_doosan_pkg/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/my_doosan_pkg
+script_dir=$base/lib/my_doosan_pkg
 [install]
-install-scripts=$base/lib/my_doosan_pkg
+install_scripts=$base/lib/my_doosan_pkg

--- a/my_environment_pkg/setup.cfg
+++ b/my_environment_pkg/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/my_environment_pkg
+script_dir=$base/lib/my_environment_pkg
 [install]
-install-scripts=$base/lib/my_environment_pkg
+install_scripts=$base/lib/my_environment_pkg

--- a/my_sphere_pkg/setup.cfg
+++ b/my_sphere_pkg/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/my_sphere_pkg
+script_dir=$base/lib/my_sphere_pkg
 [install]
-install-scripts=$base/lib/my_sphere_pkg
+install_scripts=$base/lib/my_sphere_pkg


### PR DESCRIPTION
When running colcon build on Ubuntu 22.04 the following warnings appears:
1. `/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead`
2. `/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'script_dir' instead`